### PR TITLE
Phase 2: 構造化データ・登壇者ページ・RSS導線

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,4 +29,14 @@
   - 全ページ表示は `layouts/partials/footer/custom.html`（テーマの空フック）から `"bar"` を呼ぶ。
   - 記事末尾は `layouts/partials/article/components/footer.html` の末尾で `"block"` を呼ぶ。
   - スタイルは `assets/scss/custom.scss` の「Data Visualization Japan — イベント / CTA」ブロック（テーマの CSS 変数を使用）。
-- ソーシャル導線は `hugo.toml` の `[[menu.social]]`（YouTube / Facebook / connpass）。アイコンが無いものは `assets/icons/<name>.svg` に Tabler 形式の SVG を追加（`brand-youtube` / `brand-facebook` / `calendar-event` を追加済み）。`layouts/partials/helper/icon.html` は SVG が無いとビルドエラーになる点に注意。
+- ソーシャル導線は `hugo.toml` の `[[menu.social]]`（YouTube / Facebook / connpass / RSS）。アイコンが無いものは `assets/icons/<name>.svg` に Tabler 形式の SVG を追加（`brand-youtube` / `brand-facebook` / `calendar-event` を追加済み）。`layouts/partials/helper/icon.html` は SVG が無いとビルドエラーになる点に注意。
+
+## Phase 2（構造化データ / 登壇者 / RSS）で追加した構成
+
+- 構造化データ（JSON-LD）は `layouts/partials/head/custom.html`（テーマの head フック）で出力。
+  - ホーム → `Organization`（`[[menu.social]]` の外部URLを `sameAs` に集約。RSS・相対URLは除外）。
+  - 記事（`videoId` 有）→ `VideoObject`。イベント個別ページ → `Event`（`format` に「オンライン」を含めば VirtualLocation + OnlineEventAttendanceMode）。
+  - `<script type="application/ld+json">{{ ... | jsonify | safeJS }}</script>` の `safeJS` は必須。付けないと `<script>` 内で二重エンコードされる。
+  - 同ファイル末尾で RSS フィードの autodiscovery `<link rel="alternate">` も出力。
+- 登壇者タクソノミー：`hugo.toml` の `[taxonomies]` に `speaker = "speakers"` を追加（category / tag も併記が必要）。記事 front matter は `speakers = [...]`。`/speakers/` と `/speakers/<名前>/` はテーマ標準のタクソノミーテンプレートで自動生成。メニューに `speakers`（weight 45, icon `user`）。
+  - 方針：`tags` は「トピック」、`speakers` は「登壇者」。人名は tags ではなく speakers に入れる（既存2記事は移行済み）。

--- a/content/posts/lt-all-about-dataviz/index.md
+++ b/content/posts/lt-all-about-dataviz/index.md
@@ -8,9 +8,10 @@ videoId = "CTQHwFCKpw0"
 categories = [
     "meetup","2024"
 ]
-tags = [
+speakers = [
     "矢崎裕一"
 ]
+tags = []
 image = "images/cover.png"
 +++
 

--- a/content/posts/minaka-history-viz-org/index.md
+++ b/content/posts/minaka-history-viz-org/index.md
@@ -8,9 +8,10 @@ videoId = "2jmQypjSVS0"
 categories = [
     "meetup","2022"
 ]
-tags = [
+speakers = [
     "三中信宏"
 ]
+tags = []
 image = "images/p1.png"
 weight = 10
 +++

--- a/hugo.toml
+++ b/hugo.toml
@@ -3,6 +3,11 @@ languageCode = 'ja-jp'
 title = 'Data Visualization Japan'
 theme = 'stack'
 
+[taxonomies]
+  category = 'categories'
+  tag = 'tags'
+  speaker = 'speakers'
+
 [params]
   mainSections = ['posts']
 
@@ -92,6 +97,15 @@ theme = 'stack'
       icon = 'categories'
 
   [[menu.main]]
+    identifier = 'speakers'
+    name = '登壇者'
+    url = '/speakers/'
+    weight = 45
+
+    [menu.main.params]
+      icon = 'user'
+
+  [[menu.main]]
     identifier = 'tags'
     name = 'タグ'
     url = '/tags/'
@@ -136,3 +150,11 @@ theme = 'stack'
 
   [menu.social.params]
     icon = 'calendar-event'
+
+[[menu.social]]
+  identifier = 'rss'
+  name = 'RSS'
+  url = '/index.xml'
+
+  [menu.social.params]
+    icon = 'rss'

--- a/layouts/partials/head/custom.html
+++ b/layouts/partials/head/custom.html
@@ -1,0 +1,73 @@
+{{- /*
+    構造化データ (JSON-LD) — 検索エンジン向け。
+      ホーム            → Organization（社会リンク付き）
+      記事(videoId有)   → VideoObject
+      イベント個別ページ → Event
+    テーマの head フックから読み込まれる。
+*/ -}}
+
+{{- if .IsHome -}}
+    {{- $sameAs := slice -}}
+    {{- range .Site.Menus.social -}}
+        {{- if and (ne .Identifier "rss") (hasPrefix .URL "http") -}}
+            {{- $sameAs = $sameAs | append .URL -}}
+        {{- end -}}
+    {{- end -}}
+    {{- $org := dict
+        "@context" "https://schema.org"
+        "@type" "Organization"
+        "name" .Site.Title
+        "url" .Site.BaseURL
+        "description" (.Site.Params.sidebar.subtitle | default "")
+    -}}
+    {{- with $sameAs -}}{{- $org = merge $org (dict "sameAs" .) -}}{{- end -}}
+    <script type="application/ld+json">{{ $org | jsonify | safeJS }}</script>
+{{- end -}}
+
+{{- if and .IsPage .Params.videoId -}}
+    {{- $id := .Params.videoId -}}
+    {{- $desc := .Params.summary | default (.Summary | plainify | chomp) -}}
+    {{- $video := dict
+        "@context" "https://schema.org"
+        "@type" "VideoObject"
+        "name" .Title
+        "description" $desc
+        "thumbnailUrl" (printf "https://i.ytimg.com/vi/%s/hqdefault.jpg" $id)
+        "uploadDate" (.Date.Format "2006-01-02")
+        "contentUrl" (printf "https://www.youtube.com/watch?v=%s" $id)
+        "embedUrl" (printf "https://www.youtube.com/embed/%s" $id)
+    -}}
+    <script type="application/ld+json">{{ $video | jsonify | safeJS }}</script>
+{{- end -}}
+
+{{- if and .IsPage (eq .Section "events") -}}
+    {{- $ev := time.AsTime (.Params.eventDate | default .Date) -}}
+    {{- $url := or .Params.peatix .Params.connpass .Permalink -}}
+    {{- $event := dict
+        "@context" "https://schema.org"
+        "@type" "Event"
+        "name" .Title
+        "startDate" ($ev.Format "2006-01-02T15:04:05-07:00")
+        "eventStatus" "https://schema.org/EventScheduled"
+        "url" $url
+        "organizer" (dict "@type" "Organization" "name" .Site.Title "url" .Site.BaseURL)
+    -}}
+    {{- if and .Params.format (in (string .Params.format) "オンライン") -}}
+        {{- $event = merge $event (dict
+            "eventAttendanceMode" "https://schema.org/OnlineEventAttendanceMode"
+            "location" (dict "@type" "VirtualLocation" "url" $url)
+        ) -}}
+    {{- else if .Params.venue -}}
+        {{- $event = merge $event (dict
+            "eventAttendanceMode" "https://schema.org/OfflineEventAttendanceMode"
+            "location" (dict "@type" "Place" "name" .Params.venue)
+        ) -}}
+    {{- end -}}
+    {{- $img := partialCached "helper/image" (dict "Context" . "Type" "opengraph") .RelPermalink "opengraph" -}}
+    {{- if $img.exists -}}{{- $event = merge $event (dict "image" (absURL $img.permalink)) -}}{{- end -}}
+    <script type="application/ld+json">{{ $event | jsonify | safeJS }}</script>
+{{- end -}}
+
+{{- /* RSS フィードの自動検出（フィードリーダー用） */ -}}
+<link rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" href="{{ "index.xml" | absURL }}">
+


### PR DESCRIPTION
Phase 1（#7）に続く発見性向上の施策。差分は Phase 2 のみ。

## 構造化データ（JSON-LD）
- `layouts/partials/head/custom.html` を新設
- ホーム=Organization（社会リンクを sameAs に集約）、記事=VideoObject、イベント=Event（オンラインは VirtualLocation + OnlineEventAttendanceMode）
- `jsonify | safeJS` で `<script>` 内の二重エンコードを回避

## 登壇者ページ
- `hugo.toml` の `[taxonomies]` に speaker を追加
- 既存2記事の人名を tags → speakers へ移行（tags はトピック用）
- `/speakers/` と `/speakers/<名前>/` を自動生成、メニューに「登壇者」追加

## RSS / 回遊
- フィードの autodiscovery `<link rel="alternate">` を追加
- サイドバーのソーシャルに RSS を追加

Hugo extended 0.149.0 でビルド検証済み（33ページ、JSON-LD の妥当性・登壇者ページ・RSS を確認）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYGRxS4RBK3XyfwrEeUj6i

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYGRxS4RBK3XyfwrEeUj6i)_