### PR TITLE
トップページを紹介文と写真1枚に変更

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -340,3 +340,40 @@
 .article-list--card article:not(.has-image) .article-details {
   padding-top: calc(var(--card-padding) + 4px);
 }
+
+/* ============================================================
+   トップページ（紹介文＋写真1枚）
+   ============================================================ */
+
+.home-intro {
+  background-color: var(--card-background);
+  border-radius: var(--card-border-radius);
+  box-shadow: var(--shadow-l1);
+  overflow: hidden;
+}
+
+.home-intro__figure {
+  margin: 0;
+  line-height: 0;
+}
+
+.home-intro__figure img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.home-intro__body {
+  padding: var(--card-padding);
+}
+
+.home-intro__lead {
+  margin: 0;
+  font-size: 1.6rem;
+  line-height: 2;
+  color: var(--card-text-color-main);
+}
+
+@media (min-width: 768px) {
+  .home-intro__lead { font-size: 1.7rem; }
+}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,93 +1,41 @@
 {{ define "main" }}
-    {{/* Top categories section */}}
-    {{- $tree := site.Data.category_hierarchy.categories | default (slice) -}}
-    {{- $items := slice -}}
+    {{/*
+        トップページ。コミュニティの紹介文と写真1枚のみ。
+        （カテゴリー一覧・最新記事一覧は 2026-08 に廃止）
 
-    {{- if gt (len $tree) 0 -}}
-        {{- $taxonomyMap := site.Taxonomies.categories | default dict -}}
-        {{- range sort $tree "weight" -}}
-            {{- $slug := .slug | urlize -}}
-            {{- $termPage := site.GetPage (printf "/categories/%s" $slug) -}}
-            {{- $termPages := index $taxonomyMap $slug -}}
-            {{- $count := len (or $termPages (slice)) -}}
-            {{- $items = $items | append (dict
-                "slug" $slug
-                "title" (default (humanize $slug) .title)
-                "description" .description
-                "page" $termPage
-                "count" $count
-            ) -}}
-        {{- end -}}
-    {{- else -}}
-        {{- range .Site.Taxonomies.categories.ByCount -}}
-            {{- $items = $items | append (dict
-                "slug" .Name
-                "title" .Page.Title
-                "description" .Page.Params.description
-                "page" .Page
-                "count" (len .Pages)
-            ) -}}
+        写真は assets/img/ に置く。ファイル名は home.jpg / home.png / home.webp の
+        いずれか。置かれていなければ写真のブロックごと描画しない（ビルドは通る）。
+    */}}
+    {{- $hero := "" -}}
+    {{- range slice "img/home.jpg" "img/home.jpeg" "img/home.png" "img/home.webp" -}}
+        {{- if not $hero -}}
+            {{- with resources.Get . -}}
+                {{- $hero = . -}}
+            {{- end -}}
         {{- end -}}
     {{- end -}}
 
-    {{- if gt (len $items) 0 -}}
-        <section class="home-section home-section--categories">
-            <header class="section-card section-card--plain">
-                <div class="section-details">
-                    <h3 class="section-title">カテゴリー</h3>
-                    <h1 class="section-term">Categories</h1>
-                    <p class="section-description">トップカテゴリー</p>
-                </div>
-            </header>
+    <section class="home-intro">
+        {{- with $hero }}
+            <figure class="home-intro__figure">
+                {{- if ne (path.Ext .RelPermalink) ".svg" -}}
+                    {{- $w := .Resize "960x webp q85" -}}
+                    {{- $w2 := .Resize "1920x webp q85" -}}
+                    <img src="{{ $w.RelPermalink }}"
+                        srcset="{{ $w.RelPermalink }} 960w, {{ $w2.RelPermalink }} 1920w"
+                        sizes="(min-width: 1024px) 700px, 100vw"
+                        width="{{ $w.Width }}" height="{{ $w.Height }}"
+                        alt="満席の会場で、スクリーンに資料を映しながら登壇者が話している勉強会の様子">
+                {{- else -}}
+                    <img src="{{ .RelPermalink }}" alt="Data Visualization Japan">
+                {{- end -}}
+            </figure>
+        {{- end }}
 
-            <div class="subsection-list">
-                <div class="article-list--tile">
-                    {{ range $items }}
-                        {{- $page := .page -}}
-                        {{- $href := or (and $page $page.RelPermalink) (printf "/categories/%s/" .slug) -}}
-                        <article>
-                            <a href="{{ $href }}">
-                                <div class="article-details">
-                                    <h2 class="article-title">{{ .title }}</h2>
-                                    {{ with or .description (and $page $page.Params.description) }}
-                                        <p class="article-description">{{ . }}</p>
-                                    {{ end }}
-                                    {{ if gt .count 0 }}
-                                        <p class="article-meta">{{ printf "%d 件の記事" .count }}</p>
-                                    {{ end }}
-                                </div>
-                            </a>
-                        </article>
-                    {{ end }}
-                </div>
-            </div>
-        </section>
-    {{- end -}}
-
-    {{/* Latest articles section */}}
-    {{- $pages := where .Site.RegularPages "Type" "in" .Site.Params.mainSections -}}
-    {{- $notHidden := where .Site.RegularPages "Params.hidden" "!=" true -}}
-    {{- $filtered := ($pages | intersect $notHidden) -}}
-    {{- $filtered = sort $filtered "Date" "desc" -}}
-    {{- $recentCount := default 6 .Site.Params.homepage.recentCount -}}
-    {{- $recent := first $recentCount $filtered -}}
-
-    {{- if gt (len $recent) 0 -}}
-        <section class="home-section home-section--recent">
-            <header class="section-card section-card--plain">
-                <div class="section-details">
-                    <h3 class="section-title">最新記事</h3>
-                    <h1 class="section-term">Latest Posts</h1>
-                </div>
-            </header>
-
-            <div class="article-list--compact">
-                {{ range $recent }}
-                    {{ partial "article-list/compact" . }}
-                {{ end }}
-            </div>
-        </section>
-    {{- end -}}
+        <div class="home-intro__body">
+            <p class="home-intro__lead">データ・ビジュアライゼーションにまつわる実践的なノウハウやツールなどを共有していくコミュニティです。定期的に勉強会やミートアップを開催しています。</p>
+        </div>
+    </section>
 
     {{ partialCached "footer/footer" . }}
 {{ end }}


### PR DESCRIPTION
トップページからカテゴリー一覧と最新記事一覧を削除し、コミュニティの紹介文と写真1枚のみにします。

## 変更

**削除**

- カテゴリー一覧のセクション
- 最新記事一覧のセクション

**追加**

紹介文：

> データ・ビジュアライゼーションにまつわる実践的なノウハウやツールなどを共有していくコミュニティです。定期的に勉強会やミートアップを開催しています。

写真1枚。

## 写真について

**写真は `assets/img/home.jpg` として main に直接追加済み**（2500×1667px / 296KB）なので、この PR の差分には含まれません。テンプレート側がそれを読み込みます。

- Hugo が WebP に変換し、960px（76KB）と 1920px（193KB）の2サイズを生成して `srcset` で出し分け
- 元画像 296KB に対し、実際に配信されるのは通常 76KB
- ファイルが無い場合は `<figure>` ごと描画しないので、画像を差し替え中でもビルドは落ちません

`alt` は**特定のイベント名を含めず**、写真の内容を説明する形にしています。今後写真を差し替えても文言の齟齬が起きにくいようにするためです。

```
満席の会場で、スクリーンに資料を映しながら登壇者が話している勉強会の様子
```

## ファイル

| ファイル | 内容 |
|---|---|
| `layouts/index.html` | 2セクションを削除し、紹介文＋写真のブロックに置換（-86行 / +34行） |
| `assets/scss/custom.scss` | `.home-intro` のスタイル（+37行） |

## 確認したこと

`netlify.toml` の指定バージョン（Hugo 0.149.0 extended）でビルドし、写真あり・なしの両方で通ることを確認。ブラウザでレンダリングして表示も確認済みです。

## 補足

カテゴリー一覧がトップに1枚しか出ていなかったのは、`data/category_hierarchy.toml` のトップレベルが `meetup` の1ノードだけで、年（2017〜2025）がその children だったためです。データ不足ではなく構造上の必然でした。

**右サイドバーのカテゴリー／タグのウィジェットはそのままにしています。**本文カラムの一覧を消す指示と理解したためです。サイドバーも消す場合は `hugo.toml` の `params.widgets.homepage` から外せます。