### PR TITLE
ダークモードで黒文字になっていた箇所を修正（Stack の配色規約に合わせる）

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -55,7 +55,7 @@
 
 .section-content {
   margin: 6px 0 18px;
-  color: var(--card-text-color-main);
+  color: var(--body-text-color);
 }
 
 .section-content.article-content {
@@ -135,6 +135,7 @@
 /* イベント個別ページ */
 .dvj-event { display: flex; flex-direction: column; gap: 18px; }
 .dvj-event__header {
+  color: var(--card-text-color-main);
   padding: 24px;
   border-radius: 12px;
   background: var(--card-background);
@@ -154,6 +155,7 @@
 /* セッション */
 .dvj-sessions { display: flex; flex-direction: column; gap: 14px; }
 .dvj-session {
+  color: var(--card-text-color-main);
   display: flex; gap: 16px;
   padding: 14px; border-radius: 12px;
   background: var(--card-background);
@@ -174,6 +176,7 @@
   background: var(--card-background);
   box-shadow: var(--shadow-l1, 0 2px 6px rgba(0, 0, 0, .08));
   border-top: 4px solid var(--accent-color);
+  color: var(--card-text-color-main);
   text-align: center;
 }
 .dvj-cta-block__label {
@@ -385,4 +388,11 @@
   border: 1px solid var(--card-separator-color);
   border-radius: 999px;
   padding: 2px 10px;
+}
+
+/* Stack は body に文字色を持たないため、カードの外に置くテキストは
+   --body-text-color を明示する（テーマの .section-title と同じ扱い） */
+.dvj-events-intro,
+.dvj-event__intro {
+  color: var(--body-text-color);
 }


### PR DESCRIPTION
`/events/` と `/events/<id>/` で、暗い背景の上に黒い文字が出ていた問題の修正です。

## 原因

**Stack は `body` に文字色を設定しません。**コンポーネントごとに変数から選ぶ設計です。

| 置かれる場所 | 使う変数 |
|---|---|
| カードの中 | `--card-text-color-main` / `-secondary` / `-tertiary` |
| ページ背景の上 | `--body-text-color`（テーマの `.section-title` がこの扱い） |

自作の `.dvj-*` でこの指定を省いていたため、**ブラウザ既定の黒**が残り、ダークモードで背景 `#424242` の上に `rgb(0,0,0)` が乗っていました。コントラスト比 2.09 です。

`.dvj-event-card` は最初から `color` を指定していたので正常でした。指定漏れのあったものだけが該当します。

## 修正

| セレクタ | 変更 |
|---|---|
| `.dvj-event__header` | `--card-text-color-main` を指定（イベントタイトル） |
| `.dvj-session` | 同上（セッション名・リンク行） |
| `.dvj-cta-block` | 同上 |
| `.dvj-events-intro` / `.dvj-event__intro` | `--body-text-color`（カードの外にある紹介文） |
| `.section-content` | `--card-text-color-main` → `--body-text-color`。このサイトでは背景と影を消してカードの外に置いているため |

変更は `assets/scss/custom.scss` のみです。テンプレートには触れていません。

## 確認方法

目視ではなく、**ヘッドレスブラウザで計算後の色とコントラスト比を実測**しました。祖先を遡って実効背景色を取り、比 4.5 未満の要素を列挙しています。

| ページ | dark | light |
|---|---|---|
| `/events/` | OK | OK |
| `/events/2025-meetup/` | OK | OK |
| `/categories/meetup/` | OK | OK |
| `/` | OK | OK |

修正前は `/events/2025-meetup/` だけで、`.dvj-event__title`・`.dvj-session__title`・`.dvj-session__links`・`.dvj-event__intro` が比 1.59〜2.09 で該当していました。

## 補足

ページネーションの現在ページ（`span.page-link.current`）だけ計測上ひっかかりますが、**テーマ標準のコンポーネントで、今回の変更とは無関係**です。半透明の背景色（`rgba(255,255,255,0.16)`）を計測スクリプトが合成前の値として扱っているためで、実際の見た目に問題はありません。触っていません。

---
_Generated by [Claude Code](https://claude.ai/code/session_014iB3UiFG9DAX9gLmCsJkuz)_